### PR TITLE
Bang to clear first?

### DIFF
--- a/plugin/run-interactive.vim
+++ b/plugin/run-interactive.vim
@@ -1,11 +1,14 @@
-function! s:RunInInteractiveShell(command)
+function! s:RunInInteractiveShell(command, bang)
   let saved_shellcmdflag = &shellcmdflag
   set shellcmdflag+=il
   try
-    execute '!'. a:command
+    if a:bang
+      silent execute '!clear'
+    endif
+    execute '!' . a:command
   finally
     execute 'set shellcmdflag=' . saved_shellcmdflag
   endtry
 endfunction
 
-command! -nargs=1 RunInInteractiveShell call <sid>RunInInteractiveShell(<f-args>)
+command! -bang -nargs=1 RunInInteractiveShell call <sid>RunInInteractiveShell(<f-args>, <bang>0)


### PR DESCRIPTION
Do you see value in running with bang, ie) `:Run! new command`, to clear last execution output before running the new command?

I realize this might not be cross-OS, not sure if Windows users can `clear` for example.  But if there's value in it could do an OS check.